### PR TITLE
build/docs: Renamed package to @wfcd/relics and changed readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,8 @@
 
 ## Information
 
-This version is mainly a proof of concept for potentially being added into [WFCD/warframe-items](https://github.com/WFCD/warframe-items).
+This repository is part of the build process for [warframe-items](https://github.com/WFCD/warframe-items), 
+but it does work standalone too.
 So far this repository is probably not complete and is not stable.
 No build is automatically ran either, so the data is probably quite outdated.
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
-# warframe-relic-data
+# warframe-relic-data (@wfcd/relics)
 
-[![GitHub license](https://img.shields.io/github/license/TitaniaProject/warframe-relic-data?style=for-the-badge)](https://github.com/TitaniaProject/warframe-relic-data/blob/master/License)
-[![Warframe Version](https://img.shields.io/badge/dynamic/json?color=blueviolet&label=Warframe%20Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FTitaniaProject%2Fwarframe-relic-data%2Fdevelopment%2Fdata%2Fversion.json&style=for-the-badge)](https://github.com/TitaniaProject/warframe-relic-data/blob/development/data/version.json)
+[![GitHub license](https://img.shields.io/github/license/WFCD/warframe-relic-data?style=for-the-badge)](https://github.com/WFCD/warframe-relic-data/blob/master/License)
+[![Warframe Version](https://img.shields.io/badge/dynamic/json?color=blueviolet&label=Warframe%20Version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FWFCD%2Fwarframe-relic-data%2Fdevelopment%2Fdata%2Fversion.json&style=for-the-badge)](https://github.com/WFCD/warframe-relic-data/blob/development/data/version.json)
 
 ## Information
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "warframe-relic-data",
+  "name": "@wfcd/relics",
   "version": "2.0.0",
   "description": "Relic Data for Warframe",
   "main": "dist/index.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TitaniaProject/warframe-relic-data.git"
+    "url": "git+https://github.com/WFCD/warframe-relic-data.git"
   },
   "keywords": [
     "Warframe",
@@ -20,9 +20,9 @@
   "author": "Soundofdarkness",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/TitaniaProject/warframe-relic-data/issues"
+    "url": "https://github.com/WFCD/warframe-relic-data/issues"
   },
-  "homepage": "https://github.com/TitaniaProject/warframe-relic-data#readme",
+  "homepage": "https://github.com/WFCD/warframe-relic-data#readme",
   "devDependencies": {
     "@types/node": "^18.6.4",
     "@types/node-fetch": "^2.6.2",


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
This PR changes the package name to `@wfcd/relics` and changes all links from TitaniaProject to WFCD.
Additionally I've changed the readme to remove the proof-of-concept for warframe-items part and mention the current(soon) purpose of the module.

---

### Reproduction steps
<!--
1. Changed package name to `@wfcd/relics`
2. Changed links in Readme and package.json to `WFCD/warframe-relic-data` instead of `TitaniaProject/warframe-relic-data`
3. Changed readme from mentioning the proof-of-concept for warframe-items part to now state the current(soon) purpose of the module. 
-->

---

### Evidence/screenshot/link to line

All changes are in the Readme.md and in package.json.

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Docs/Maintenance]**
