### PR TITLE
fix(#367): add .toLowerCase to prevent silent misses

### DIFF
--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -119,7 +119,9 @@ export class Generator {
     const rewards = rawRelic.rewards.map((rawReward) => {
       const { chance } = rawReward;
       const { rarity } = rawReward;
-      const wfmInfo = this.wfmItems?.data.find((x) => x.i18n.en.name === rawReward.itemName);
+      const wfmInfo = this.wfmItems?.data.find((x) => {
+        return x.i18n.en.name.toLowerCase() === rawReward.itemName.toLowerCase();
+      });
       const isSpecial = ['Forma', 'Kuva', 'Exilus', 'Riven'].find((x) =>
         // eslint-disable-next-line @typescript-eslint/comma-dangle
         rawReward.itemName.toLowerCase().includes(x.toLowerCase())
@@ -153,7 +155,9 @@ export class Generator {
       });
     }
 
-    const wfm = this.wfmItems?.data.find((x) => x.i18n.en.name === `${name.trim()} Relic`);
+    const wfm = this.wfmItems?.data.find((x) => {
+      return x.i18n.en.name.toLowerCase() === `${name.trim()} Relic`.toLowerCase();
+    });
     if (!wfm) {
       logger.error(`Failed to get relic item from wfm: ${name}`);
     }


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
closes #367

---

### Reproduction steps
There was a case-sensitive equality check that could lead to silent misses in matching.

---

### Evidence/screenshot/link to line
https://github.com/WFCD/warframe-relic-data/blob/ac3d21dc5821c0fb3321341560729d779ce484fc/src/Generator.ts#L122
https://github.com/WFCD/warframe-relic-data/blob/ac3d21dc5821c0fb3321341560729d779ce484fc/src/Generator.ts#L156


### Considerations
- Does this contain a new dependency? **No**
- Does this introduce opinionated data formatting or manual data entry? **No**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **No, did not change anything**
- Have I run the linter? **Yes**
- Is is a bug fix, feature request, or enhancement? **Bug Fix**
